### PR TITLE
setup: declare yubicommon package to fix installation from sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from u2flib_host.yubicommon.setup import setup
+from u2flib_host.yubicommon.setup import setup, find_packages
 
 
 setup(
@@ -36,7 +36,7 @@ setup(
     maintainer='Yubico Open Source Maintainers',
     maintainer_email='ossmaint@yubico.com',
     url='https://github.com/Yubico/python-u2flib-host',
-    packages=['u2flib_host'],
+    packages=find_packages(include=['u2flib_host', 'u2flib_host.yubicommon']),
     scripts=['scripts/u2f-register', 'scripts/u2f-authenticate'],
     install_requires=['requests', 'hidapi>=0.7.99'],
     test_suite='test',


### PR DESCRIPTION
Sample of the error this fixes
```bash
alex@martha:/tmp$ tar xf python-u2flib-host-2.2.1.tar.gz 
alex@martha:/tmp$ cd python-u2flib-host-2.2.1/
alex@martha:/tmp/python-u2flib-host-2.2.1$ python setup.py egg_info
Traceback (most recent call last):
  File "setup.py", line 28, in <module>
    from u2flib_host.yubicommon.setup import setup
ImportError: No module named yubicommon.setup
```