### PR TITLE
Add tox and travis continuous integration support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = u2flib_host
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ dist/
 .ropeproject/
 ChangeLog
 man/*.1
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libudev-dev libusb-1.0.0-dev
+  - sudo apt-get build-dep m2crypto
 
 install:
   - pip install -r dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+
+python:
+  - 2.7
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+install:
+  - pip install -r dev-requirements.txt
+  - pip install -e .
+
+script:
+  - coverage run setup.py test
+
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: required
 
 python:
   - 2.7
@@ -6,6 +7,10 @@ python:
 cache:
   directories:
     - $HOME/.cache/pip
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libudev-dev libusb-1.0.0-dev
 
 install:
   - pip install -r dev-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+coverage
+coveralls

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 coverage
 coveralls
+Cython # For building hidapi in Tox and on Travis

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 coverage
 coveralls
 Cython # For building hidapi in Tox and on Travis
+M2Crypto

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from u2flib_host.yubicommon.setup import setup
+from u2flib_host.yubicommon.setup import setup, find_packages
 
 
 setup(
@@ -36,7 +36,7 @@ setup(
     maintainer='Yubico Open Source Maintainers',
     maintainer_email='ossmaint@yubico.com',
     url='https://github.com/Yubico/python-u2flib-host',
-    packages=['u2flib_host'],
+    packages=find_packages(include=['u2flib_host', 'u2flib_host.yubicommon']),
     scripts=['scripts/u2f-register', 'scripts/u2f-authenticate'],
     install_requires=['requests', 'hidapi>=0.7.99'],
     test_suite='test',

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,10 @@ setup(
     scripts=['scripts/u2f-register', 'scripts/u2f-authenticate'],
     install_requires=['requests', 'hidapi>=0.7.99'],
     test_suite='test',
+    tests_require=['M2Crypto'],
+    extras_require={
+        'soft_device': ['M2Crypto'],
+    },
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist =
+    py27
+
+[testenv]
+develop = True
+deps =
+    -r{toxinidir}/dev-requirements.txt
+commands =
+    coverage run setup.py test
+    coverage report
+    coverage html


### PR DESCRIPTION
Example build: https://travis-ci.org/moreati/python-u2flib-host/builds/73087084
Example coverage: https://coveralls.io/builds/3163380

Example badges, could be added to the README and on PyPI:
[![Build Status](https://travis-ci.org/moreati/python-u2flib-host.svg?branch=ci)](https://travis-ci.org/moreati/python-u2flib-host) [![Coverage Status](https://coveralls.io/repos/moreati/python-u2flib-host/badge.svg?branch=ci&service=github)](https://coveralls.io/github/moreati/python-u2flib-host?branch=ci)