### PR TITLE
Support CPython 3.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 
 python:
   - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
 
 cache:
   directories:

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+* Version 3.0.0 (unreleased)
+ ** Added support for Python 3.3+
+ ** utils.rand_bytes() now sources bytes from os.urandom()
+ ** utils.websafe_encode() now returns text strings (unicode() on Python 2.x,
+    str() on Python 3.x)
+ ** soft.SoftU2FDevice() now stores keys, key handles and app params as text
+    strings
+
 * Version 2.3.0 (unreleased)
  ** Replace M2Crypto with Cryptography.
 

--- a/README
+++ b/README
@@ -25,7 +25,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", \
 ----
 
 === Dependencies ===
-u2flib-host is compatible with Python 2.7.
+u2flib-host is compatible with CPython 2.7, 3.3 onwards.
 
 To support HID devices, u2flib-host uses hidapi, which has a few dependencies
 for building. On a Debian based system, run the following command before
@@ -34,7 +34,7 @@ installation:
   # apt-get install build-essential python-dev cython libusb-1.0-0-dev \
     libudev-dev
 
-The soft U2F device implementation requires crytography, the build
+The soft U2F device implementation requires link:https://pypi.python.org/pypi/cryptography[cryptography], the build
 dependencies can be installed with
 
   # apt-get install libffi-dev libssl-dev

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,12 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 2 :: Only',
+        'Programming Language :: Python :: 3'
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',

--- a/test/test_exc.py
+++ b/test/test_exc.py
@@ -1,0 +1,13 @@
+
+import unittest
+
+from u2flib_host import exc
+
+
+class APDUErrorTest(unittest.TestCase):
+    def test_init(self):
+        error = exc.APDUError(0x3039)
+        self.assertEqual(error.args[0], '0x3039')
+        self.assertEqual(error.code, 0x3039)
+        self.assertEqual(error.sw1, 0x30)
+        self.assertEqual(error.sw2, 0x39)

--- a/test/test_hid.py
+++ b/test/test_hid.py
@@ -43,9 +43,9 @@ class HidTest(unittest.TestCase):
             dev.close()
 
     def test_echo(self):
-        msg1 = 'hello world!'
-        msg2 = '            '
-        msg3 = ''
+        msg1 = b'hello world!'
+        msg2 = b'            '
+        msg3 = b''
         with self.get_device() as dev:
             self.assertEqual(dev.send_apdu(0x40, 0, 0, msg1), msg1)
             self.assertEqual(dev.send_apdu(0x40, 0, 0, msg2), msg2)

--- a/test/test_hid.py
+++ b/test/test_hid.py
@@ -38,7 +38,7 @@ class HidTest(unittest.TestCase):
 
     def test_open_close(self):
         dev = self.get_device()
-        for i in xrange(0, 10):
+        for i in range(0, 10):
             dev.open()
             dev.close()
 

--- a/test/test_soft.py
+++ b/test/test_soft.py
@@ -1,0 +1,55 @@
+
+import os
+import base64
+import struct
+import tempfile
+import unittest
+
+from u2flib_host.soft import SoftU2FDevice
+from u2flib_host.constants import INS_ENROLL, INS_SIGN
+
+CLIENT_PARAM = b'clientABCDEFGHIJKLMNOPQRSTUVWXYZ' # 32 bytes
+APP_PARAM =    b'test_SoftU2FDevice0123456789ABCD' # 32 bytes
+
+class TestSoftU2FDevice(unittest.TestCase):
+    def setUp(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b'{"counter": 0, "keys": {}}')
+            self.device_path = f.name
+
+    def tearDown(self):
+        os.unlink(self.device_path)
+
+    def test_init(self):
+        dev = SoftU2FDevice(self.device_path)
+        self.assertEqual(dev.data['counter'], 0)
+        self.assertEqual(dev.data['keys'], {})
+
+    def test_get_supported_versions(self):
+        dev = SoftU2FDevice(self.device_path)
+        self.assertEqual(dev.get_supported_versions(), ['U2F_V2'])
+
+    def test_registeration(self):
+        dev = SoftU2FDevice(self.device_path)
+        request = struct.pack('32s 32s', CLIENT_PARAM, APP_PARAM)
+        response = dev.send_apdu(INS_ENROLL, data=request)
+        self.assertEqual(dev.data['counter'], 0)
+        self.assertTrue(len(dev.data['keys']), 1)
+
+        pub_key, key_handle_len, key_handle, cert, signature = struct.unpack('x 65s B 64s %is 32s' % (len(response)-(1+65+1+64+32),), response)
+        self.assertEqual(len(key_handle), key_handle_len)
+        kh_hex = base64.b16encode(key_handle).decode('ascii')
+        self.assertIn(kh_hex, dev.data['keys'])
+        self.assertEqual(base64.b16decode(dev.data['keys'][kh_hex]['app_param']), APP_PARAM)
+        self.assertEqual(dev.data['keys'][kh_hex]['priv_key'].split('\n')[0],
+                         '-----BEGIN PRIVATE KEY-----')
+
+        request = struct.pack('32s 32s B %is' % key_handle_len,
+                              CLIENT_PARAM, APP_PARAM, key_handle_len, key_handle)
+        response = dev.send_apdu(INS_SIGN, data=request)
+        self.assertEqual(dev.data['counter'], 1)
+
+        touch, counter, signature = struct.unpack('>? I %is' % (len(response)-(1+4),), response)
+        self.assertTrue(touch)
+        self.assertEqual(counter, 1)
+

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -32,22 +32,30 @@ class TestWebSafe(unittest.TestCase):
     # Base64 vectors adapted from https://tools.ietf.org/html/rfc4648#section-10
 
     def test_websafe_decode(self):
-       self.assertEqual(websafe_decode(''), '')
-       self.assertEqual(websafe_decode('Zg'), 'f')
-       self.assertEqual(websafe_decode('Zm8'), 'fo')
-       self.assertEqual(websafe_decode('Zm9v'), 'foo')
-       self.assertEqual(websafe_decode('Zm9vYg'), 'foob')
-       self.assertEqual(websafe_decode('Zm9vYmE'), 'fooba')
-       self.assertEqual(websafe_decode('Zm9vYmFy'), 'foobar')
+        self.assertEqual(websafe_decode(b''), b'')
+        self.assertEqual(websafe_decode(b'Zg'), b'f')
+        self.assertEqual(websafe_decode(b'Zm8'), b'fo')
+        self.assertEqual(websafe_decode(b'Zm9v'), b'foo')
+        self.assertEqual(websafe_decode(b'Zm9vYg'), b'foob')
+        self.assertEqual(websafe_decode(b'Zm9vYmE'), b'fooba')
+        self.assertEqual(websafe_decode(b'Zm9vYmFy'), b'foobar')
+
+    def test_websafe_decode_unicode(self):
+        self.assertEqual(websafe_decode(u''), b'')
+        self.assertEqual(websafe_decode(u'Zm9vYmFy'), b'foobar')
 
     def test_websafe_encode(self):
-       self.assertEqual(websafe_encode(''), '')
-       self.assertEqual(websafe_encode('f'), 'Zg')
-       self.assertEqual(websafe_encode('fo'), 'Zm8')
-       self.assertEqual(websafe_encode('foo'), 'Zm9v')
-       self.assertEqual(websafe_encode('foob'), 'Zm9vYg')
-       self.assertEqual(websafe_encode('fooba'), 'Zm9vYmE')
-       self.assertEqual(websafe_encode('foobar'), 'Zm9vYmFy')
+        self.assertEqual(websafe_encode(b''), u'')
+        self.assertEqual(websafe_encode(b'f'), u'Zg')
+        self.assertEqual(websafe_encode(b'fo'), u'Zm8')
+        self.assertEqual(websafe_encode(b'foo'), u'Zm9v')
+        self.assertEqual(websafe_encode(b'foob'), u'Zm9vYg')
+        self.assertEqual(websafe_encode(b'fooba'), u'Zm9vYmE')
+        self.assertEqual(websafe_encode(b'foobar'), u'Zm9vYmFy')
+
+    def test_websafe_encode_unicode(self):
+        self.assertEqual(websafe_encode(u''), u'')
+        self.assertEqual(websafe_encode(u'foobar'), u'Zm9vYmFy')
 
 
 class TestH(unittest.TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -16,14 +16,14 @@ class TestU2Str(unittest.TestCase):
             u'greeting_en': u'Hello world',
             u'greeting_se': u'Hallå världen',
             u'recursive': {
-                'plaintext': [u'foo', 'bar', u'BΛZ'],
+                b'plaintext': [u'foo', b'bar', u'BΛZ'],
             },
         }
         self.assertEqual(u2str(data1), {
-            'greeting_en': 'Hello world',
-            'greeting_se': 'Hall\xc3\xa5 v\xc3\xa4rlden', # utf-8 encoded
-            'recursive': {
-                'plaintext': ['foo', 'bar', 'B\xce\x9bZ'],
+            b'greeting_en': b'Hello world',
+            b'greeting_se': b'Hall\xc3\xa5 v\xc3\xa4rlden', # utf-8 encoded
+            b'recursive': {
+                b'plaintext': [b'foo', b'bar', b'B\xce\x9bZ'],
             },
         })
 
@@ -62,8 +62,8 @@ class TestH(unittest.TestCase):
     # SHA-256 vectors adapted from http://www.nsrl.nist.gov/testdata/
 
     def test_H(self):
-        self.assertEqual(H('abc'),
-            '\xbax\x16\xbf\x8f\x01\xcf\xeaAA@\xde]\xae"#\xb0'
-            '\x03a\xa3\x96\x17z\x9c\xb4\x10\xffa\xf2\x00\x15\xad'
+        self.assertEqual(H(b'abc'),
+            b'\xbax\x16\xbf\x8f\x01\xcf\xeaAA@\xde]\xae"#\xb0'
+            b'\x03a\xa3\x96\x17z\x9c\xb4\x10\xffa\xf2\x00\x15\xad'
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist =
-    py27
+    py27,
+    py33,
+    py34,
+    py35,
 
 [testenv]
 develop = True
@@ -10,3 +13,6 @@ commands =
     coverage run setup.py test
     coverage report
     coverage html
+    # Allow any U2F attached HID device time reset itself. Otherwise, if a U2F
+    # HID device is attached then only the first environment to run succeeds.
+    python -c "import time; time.sleep(2)"

--- a/u2flib_host/__init__.py
+++ b/u2flib_host/__init__.py
@@ -25,4 +25,4 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-__version__ = "2.3.0-dev0"
+__version__ = "3.0.0-dev0"

--- a/u2flib_host/appid.py
+++ b/u2flib_host/appid.py
@@ -93,7 +93,7 @@ class AppIDVerifier(object):
 
     def valid_facets(self, app_id, facets):
         app_id_ls = self.least_specific(app_id)
-        return filter(lambda f: self.facet_is_valid(app_id_ls, f), facets)
+        return [f for f in facets if self.facet_is_valid(app_id_ls, f)]
 
     def facet_is_valid(self, app_id_ls, facet):
         # The scheme of URLs in ids must identify either an application

--- a/u2flib_host/authenticate.py
+++ b/u2flib_host/authenticate.py
@@ -28,6 +28,8 @@
 from u2flib_host import u2f, exc, __version__
 from u2flib_host.constants import APDU_USE_NOT_SATISFIED
 from u2flib_host.utils import u2str
+from u2flib_host.yubicommon.compat import text_type
+
 import time
 import json
 import argparse
@@ -99,7 +101,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    facet = unicode(args.facet, sys.stdin.encoding or sys.getdefaultencoding())
+    facet = text_type(args.facet, sys.stdin.encoding or sys.getdefaultencoding())
     if args.infile:
         with open(args.infile, 'r') as f:
             data = f.read()

--- a/u2flib_host/authenticate.py
+++ b/u2flib_host/authenticate.py
@@ -25,6 +25,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 from u2flib_host import u2f, exc, __version__
 from u2flib_host.constants import APDU_USE_NOT_SATISFIED
 from u2flib_host.utils import u2str
@@ -125,7 +127,7 @@ def main():
         sys.stderr.write('Output written to %s\n' % args.outfile)
     else:
         sys.stderr.write('\n---Result---\n')
-        print json.dumps(result)
+        print(json.dumps(result))
 
 
 if __name__ == '__main__':

--- a/u2flib_host/device.py
+++ b/u2flib_host/device.py
@@ -26,7 +26,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from u2flib_host.constants import APDU_OK
+from u2flib_host.yubicommon.compat import int2byte
 from u2flib_host import exc
+import struct
 import sys
 
 INS_GET_VERSION = 0x03
@@ -87,27 +89,27 @@ class U2FDevice(object):
         # Subclasses should implement this.
         raise NotImplementedError('_do_send_apdu not implemented!')
 
-    def send_apdu(self, ins, p1=0, p2=0, data=''):
+    def send_apdu(self, ins, p1=0, p2=0, data=b''):
         """
         Sends an APDU to the device, and waits for a response.
         """
         if data is None:
-            data = ''
+            data = b''
         elif isinstance(data, int):
-            data = chr(data)
+            data = int2byte(data)
 
         size = len(data)
         l0 = size >> 16 & 0xff
         l1 = size >> 8 & 0xff
         l2 = size & 0xff
-        apdu_data = "%c%c%c%c%c%c%c%s%c%c" % \
-            (0, ins, p1, p2, l0, l1, l2, data, 0x04, 0x00)
+        apdu_data = struct.pack('B B B B B B B %is B B' % size,
+                                0, ins, p1, p2, l0, l1, l2, data, 0x04, 0x00)
         try:
             resp = self._do_send_apdu(apdu_data)
         except Exception as e:
             # Wrap exception, keeping trace
             raise exc.DeviceError(e), None, sys.exc_info()[2]
-        status = int(resp[-2:].encode('hex'), 16)
+        status = struct.unpack('>H', resp[-2:])[0]
         data = resp[:-2]
         if status != APDU_OK:
             raise exc.APDUError(status)

--- a/u2flib_host/device.py
+++ b/u2flib_host/device.py
@@ -107,8 +107,8 @@ class U2FDevice(object):
         try:
             resp = self._do_send_apdu(apdu_data)
         except Exception as e:
-            # Wrap exception, keeping trace
-            raise exc.DeviceError(e), None, sys.exc_info()[2]
+            # TODO Use six.reraise if/when Six becomes an agreed dependency.
+            raise exc.DeviceError(e)
         status = struct.unpack('>H', resp[-2:])[0]
         data = resp[:-2]
         if status != APDU_OK:

--- a/u2flib_host/hid_transport.py
+++ b/u2flib_host/hid_transport.py
@@ -25,6 +25,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 import os
 try:
     import hidraw as hid  # Prefer hidraw
@@ -119,7 +121,7 @@ class HIDDevice(U2FDevice):
         nonce = os.urandom(8)
         resp = self.call(CMD_INIT, nonce)
         while resp[:8] != nonce:
-            print "Wrong nonce, read again..."
+            print("Wrong nonce, read again...")
             resp = self._read_resp(self.cid, CMD_INIT)
         self.cid = resp[8:12]
 

--- a/u2flib_host/hid_transport.py
+++ b/u2flib_host/hid_transport.py
@@ -34,6 +34,7 @@ except ImportError:
     import hid
 from time import time
 from u2flib_host.device import U2FDevice
+from u2flib_host.yubicommon.compat import byte2int, int2byte
 from u2flib_host import exc
 
 DEVICES = [
@@ -104,7 +105,7 @@ class HIDDevice(U2FDevice):
 
     def __init__(self, path):
         self.path = path
-        self.cid = "ffffffff".decode('hex')
+        self.cid = b"\xff\xff\xff\xff"
 
     def open(self):
         self.handle = hid.device()
@@ -126,7 +127,7 @@ class HIDDevice(U2FDevice):
         self.cid = resp[8:12]
 
     def set_mode(self, mode):
-        data = ("%02x0f0000" % mode).decode('hex')
+        data = mode + b"\x0f\x00\x00"
         self.call(U2FHID_YUBIKEY_DEVICE_CONFIG, data)
 
     def _do_send_apdu(self, apdu_data):
@@ -137,42 +138,44 @@ class HIDDevice(U2FDevice):
 
     def _send_req(self, cid, cmd, data):
         size = len(data)
-        bc_l = chr(size & 0xff)
-        bc_h = chr(size >> 8 & 0xff)
-        payload = cid + chr(TYPE_INIT | cmd) + bc_h + bc_l + \
+        bc_l = int2byte(size & 0xff)
+        bc_h = int2byte(size >> 8 & 0xff)
+        payload = cid + int2byte(TYPE_INIT | cmd) + bc_h + bc_l + \
             data[:HID_RPT_SIZE - 7]
-        payload += '\0' * (HID_RPT_SIZE - len(payload))
-        self.handle.write([0] + map(ord, payload))
+        payload += b'\0' * (HID_RPT_SIZE - len(payload))
+        self.handle.write([0] + [byte2int(c) for c in payload])
         data = data[HID_RPT_SIZE - 7:]
         seq = 0
         while len(data) > 0:
-            payload = cid + chr(0x7f & seq) + data[:HID_RPT_SIZE - 5]
-            payload += '\0' * (HID_RPT_SIZE - len(payload))
-            self.handle.write([0] + map(ord, payload))
+            payload = cid + int2byte(0x7f & seq) + data[:HID_RPT_SIZE - 5]
+            payload += b'\0' * (HID_RPT_SIZE - len(payload))
+            self.handle.write([0] + [byte2int(c) for c in payload])
             data = data[HID_RPT_SIZE - 5:]
             seq += 1
 
     def _read_resp(self, cid, cmd):
-        resp = '.'
-        header = cid + chr(TYPE_INIT | cmd)
+        resp = b'.'
+        header = cid + int2byte(TYPE_INIT | cmd)
         while resp and resp[:5] != header:
-            resp = ''.join(map(chr, _read_timeout(self.handle, HID_RPT_SIZE)))
-            if resp[:5] == cid + chr(STAT_ERR):
-                raise U2FHIDError(ord(resp[6]))
+            resp_vals = _read_timeout(self.handle, HID_RPT_SIZE)
+            resp = b''.join(int2byte(v) for v in resp_vals)
+            if resp[:5] == cid + int2byte(STAT_ERR):
+                raise U2FHIDError(byte2int(resp[6]))
 
         if not resp:
             raise exc.DeviceError("Invalid response from device!")
 
-        data_len = (ord(resp[5]) << 8) + ord(resp[6])
+        data_len = (byte2int(resp[5]) << 8) + byte2int(resp[6])
         data = resp[7:min(7 + data_len, HID_RPT_SIZE)]
         data_len -= len(data)
 
         seq = 0
         while data_len > 0:
-            resp = ''.join(map(chr, _read_timeout(self.handle, HID_RPT_SIZE)))
+            resp_vals = _read_timeout(self.handle, HID_RPT_SIZE)
+            resp = b''.join(int2byte(v) for v in resp_vals)
             if resp[:4] != cid:
                 raise exc.DeviceError("Wrong CID from device!")
-            if ord(resp[4]) != seq & 0x7f:
+            if byte2int(resp[4:5]) != seq & 0x7f:
                 raise exc.DeviceError("Wrong SEQ from device!")
             seq += 1
             new_data = resp[5:min(5 + data_len, HID_RPT_SIZE)]
@@ -180,9 +183,9 @@ class HIDDevice(U2FDevice):
             data += new_data
         return data
 
-    def call(self, cmd, data=''):
+    def call(self, cmd, data=b''):
         if isinstance(data, int):
-            data = chr(data)
+            data = int2byte(data)
 
         self._send_req(self.cid, cmd, data)
         return self._read_resp(self.cid, cmd)

--- a/u2flib_host/register.py
+++ b/u2flib_host/register.py
@@ -28,6 +28,8 @@
 from u2flib_host import u2f, exc, __version__
 from u2flib_host.constants import APDU_USE_NOT_SATISFIED
 from u2flib_host.utils import u2str
+from u2flib_host.yubicommon.compat import text_type
+
 import time
 import json
 import argparse
@@ -91,7 +93,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    facet = unicode(args.facet, sys.stdin.encoding or sys.getdefaultencoding())
+    facet = text_type(args.facet, sys.stdin.encoding or sys.getdefaultencoding())
     if args.infile:
         with open(args.infile, 'r') as f:
             data = f.read()

--- a/u2flib_host/register.py
+++ b/u2flib_host/register.py
@@ -25,6 +25,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 from u2flib_host import u2f, exc, __version__
 from u2flib_host.constants import APDU_USE_NOT_SATISFIED
 from u2flib_host.utils import u2str
@@ -116,7 +118,7 @@ def main():
         sys.stderr.write('Output written to %s\n' % args.outfile)
     else:
         sys.stderr.write('\n---Result---\n')
-        print json.dumps(result)
+        print(json.dumps(result))
 
 
 if __name__ == '__main__':

--- a/u2flib_host/soft.py
+++ b/u2flib_host/soft.py
@@ -25,12 +25,14 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 try:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes, serialization
     from cryptography.hazmat.primitives.asymmetric import ec
 except ImportError:
-    print "The soft U2F token requires cryptography."
+    print("The soft U2F token requires cryptography.")
     raise
 
 from u2flib_host.utils import H

--- a/u2flib_host/soft.py
+++ b/u2flib_host/soft.py
@@ -38,7 +38,9 @@ except ImportError:
 from u2flib_host.utils import H
 from u2flib_host.device import U2FDevice
 from u2flib_host.constants import INS_ENROLL, INS_SIGN
+from u2flib_host.yubicommon.compat import byte2int, int2byte
 from u2flib_host import exc
+import base64
 import json
 import os
 import struct
@@ -46,7 +48,7 @@ import struct
 # AKA NID_X9_62_prime256v1 in OpenSSL
 CURVE = ec.SECP256R1
 
-CERT = """
+CERT = base64.b64decode(b"""
 MIIBhzCCAS6gAwIBAgIJAJm+6LEMouwcMAkGByqGSM49BAEwITEfMB0GA1UEAwwW
 WXViaWNvIFUyRiBTb2Z0IERldmljZTAeFw0xMzA3MTcxNDIxMDNaFw0xNjA3MTYx
 NDIxMDNaMCExHzAdBgNVBAMMFll1YmljbyBVMkYgU29mdCBEZXZpY2UwWTATBgcq
@@ -56,14 +58,19 @@ FgQUDai/k1dOImjupkubYxhOkoX3sZ4wHwYDVR0jBBgwFoAUDai/k1dOImjupkub
 YxhOkoX3sZ4wDAYDVR0TBAUwAwEB/zAJBgcqhkjOPQQBA0gAMEUCIFyVmXW7zlnY
 VWhuyCbZ+OKNtSpovBB7A5OHAH52dK9/AiEA+mT4tz5eJV8W2OwVxcq6ZIjrwqXc
 jXSy2G0k27yAUDk=
-""".decode('base64')
-CERT_PRIV = """
+""")
+CERT_PRIV = b"""
 -----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIMyk3gKcDg5lsYdl48fZoIFORhAc9cQxmn2Whv/+ya+2oAoGCCqGSM49
 AwEHoUQDQgAEO+GX3XN+mD2fsN4J51xDyAZdSd6aJeiL4kQDHP4QiGRWww8DLOG0
 lnhXcKoxn4w5SAgK3ZozFpwxf1whrx2BLQ==
 -----END EC PRIVATE KEY-----
 """
+
+
+def _b16text(s):
+    """Encode a byte string s as base16 in a textual (unicode) string."""
+    return base64.b16encode(s).decode('ascii')
 
 
 class SoftU2FDevice(U2FDevice):
@@ -91,7 +98,7 @@ class SoftU2FDevice(U2FDevice):
     def get_supported_versions(self):
         return ['U2F_V2']
 
-    def send_apdu(self, ins, p1=0, p2=0, data=''):
+    def send_apdu(self, ins, p1=0, p2=0, data=b''):
         if ins == INS_ENROLL:
             return self._register(data)
         elif ins == INS_SIGN:
@@ -118,9 +125,9 @@ class SoftU2FDevice(U2FDevice):
             serialization.PrivateFormat.PKCS8,
             serialization.NoEncryption(),
         )
-        self.data['keys'][key_handle.encode('hex')] = {
-            'priv_key': priv_key_pem,
-            'app_param': app_param.encode('hex')
+        self.data['keys'][_b16text(key_handle)] = {
+            'priv_key': priv_key_pem.decode('ascii'),
+            'app_param': _b16text(app_param),
         }
         self._persist()
 
@@ -131,11 +138,11 @@ class SoftU2FDevice(U2FDevice):
         )
         signer = cert_priv.signer(ec.ECDSA(hashes.SHA256()))
         signer.update(
-            chr(0x00) + app_param + client_param + key_handle + pub_key
+            b'\x00' + app_param + client_param + key_handle + pub_key
         )
         signature = signer.finalize()
 
-        raw_response = chr(0x05) + pub_key + chr(len(key_handle)) + \
+        raw_response = b'\x05' + pub_key + int2byte(len(key_handle)) + \
             key_handle + cert + signature
 
         return raw_response
@@ -143,14 +150,14 @@ class SoftU2FDevice(U2FDevice):
     def _authenticate(self, data):
         client_param = data[:32]
         app_param = data[32:64]
-        kh_len = ord(data[64])
-        key_handle = data[65:65 + kh_len].encode('hex')
+        kh_len = byte2int(data[64])
+        key_handle = _b16text(data[65:65+kh_len])
         if key_handle not in self.data['keys']:
             raise ValueError("Unknown key handle!")
 
         # Unwrap:
         unwrapped = self.data['keys'][key_handle]
-        if app_param != unwrapped['app_param'].decode('hex'):
+        if app_param != base64.b16decode(unwrapped['app_param']):
             raise ValueError("Incorrect app param!")
         priv_pem = unwrapped['priv_key'].encode('ascii')
         privu = serialization.load_pem_private_key(
@@ -162,7 +169,7 @@ class SoftU2FDevice(U2FDevice):
         self._persist()
 
         # Create signature
-        touch = chr(1)  # Always indicate user presence
+        touch = b'\x01' # Always indicate user presence
         counter = struct.pack('>I', self.data['counter'])
 
         signer = privu.signer(ec.ECDSA(hashes.SHA256()))

--- a/u2flib_host/u2f_v2.py
+++ b/u2flib_host/u2f_v2.py
@@ -28,6 +28,8 @@
 from u2flib_host.constants import INS_ENROLL, INS_SIGN
 from u2flib_host.utils import websafe_decode, websafe_encode, H
 from u2flib_host.appid import verify_facet
+from u2flib_host.yubicommon.compat import string_types
+
 import json
 
 VERSION = 'U2F_V2'
@@ -45,7 +47,7 @@ def register(device, data, facet):
 
     """
 
-    if isinstance(data, basestring):
+    if isinstance(data, string_types):
         data = json.loads(data)
 
     if data['version'] != VERSION:
@@ -88,7 +90,7 @@ def authenticate(device, data, facet, check_only=False):
 
     """
 
-    if isinstance(data, basestring):
+    if isinstance(data, string_types):
         data = json.loads(data)
 
     if data['version'] != VERSION:

--- a/u2flib_host/utils.py
+++ b/u2flib_host/utils.py
@@ -41,7 +41,7 @@ __all__ = [
 def u2str(data):
     """Recursivly converts unicode object to UTF-8 formatted strings."""
     if isinstance(data, dict):
-        return {u2str(k): u2str(v) for k, v in data.iteritems()}
+        return {u2str(k): u2str(v) for k, v in data.items()}
     elif isinstance(data, list):
         return [u2str(x) for x in data]
     elif isinstance(data, text_type):

--- a/u2flib_host/utils.py
+++ b/u2flib_host/utils.py
@@ -39,7 +39,7 @@ __all__ = [
 
 
 def u2str(data):
-    """Recursivly converts unicode object to UTF-8 formatted strings."""
+    """Recursively converts unicode objects to UTF-8 encoded byte strings."""
     if isinstance(data, dict):
         return {u2str(k): u2str(v) for k, v in data.items()}
     elif isinstance(data, list):

--- a/u2flib_host/utils.py
+++ b/u2flib_host/utils.py
@@ -51,14 +51,16 @@ def u2str(data):
 
 
 def websafe_decode(data):
-    if isinstance(data, unicode):
-        data = data.encode('utf-8')
-    data += '=' * (-len(data) % 4)
+    if isinstance(data, text_type):
+        data = data.encode('ascii')
+    data += b'=' * (-len(data) % 4)
     return urlsafe_b64decode(data)
 
 
 def websafe_encode(data):
-    return urlsafe_b64encode(data).replace('=', '')
+    if isinstance(data, text_type):
+        data = data.encode('ascii')
+    return urlsafe_b64encode(data).replace(b'=', b'').decode('ascii')
 
 
 def H(data):

--- a/u2flib_host/utils.py
+++ b/u2flib_host/utils.py
@@ -25,6 +25,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from u2flib_host.yubicommon.compat import text_type
+
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from hashlib import sha256
 
@@ -42,7 +44,7 @@ def u2str(data):
         return {u2str(k): u2str(v) for k, v in data.iteritems()}
     elif isinstance(data, list):
         return [u2str(x) for x in data]
-    elif isinstance(data, unicode):
+    elif isinstance(data, text_type):
         return data.encode('utf-8')
     else:
         return data


### PR DESCRIPTION
Sorry for the wait. Noteworthy changes:

- Bumped the version to 3.0.0-dev0
- `websafe_decode()` and `websafe_encode()` behave the same as in pythonu2flib-server 4.0. i.e. `websafe_encode()` now returns a textual (unicode) string.
- Added a very rudimentary test case for `SoftU2FDeive`

There's one more item to do. 

- [X]  Work out how to fix `raise exc.DeviceError(e), None, sys.exc_info()[2]` in device.py, which is invalid syntax on Python 3.x.

Refs #11