### PR TITLE
Fix compatibility with some U2F tokens

### DIFF
--- a/u2flib_host/device.py
+++ b/u2flib_host/device.py
@@ -100,7 +100,7 @@ class U2FDevice(object):
         l1 = size >> 8 & 0xff
         l2 = size & 0xff
         apdu_data = struct.pack('B B B B B B B %is B B' % size,
-                                0, ins, p1, p2, l0, l1, l2, data, 0x04, 0x00)
+                                0, ins, p1, p2, l0, l1, l2, data, 0x00, 0x00)
         try:
             resp = self._do_send_apdu(apdu_data)
         except Exception as e:


### PR DESCRIPTION
At my company we use a variety of U2F tokens (including a range of Yubico products). We have recently discovered that some tokens do not work with this library because they expect to have the maximum length of the response data set to 65536 bytes.

In python-u2flib-host, the maximum length of the response data is hardcoded to 1024 bytes. I propose to change it to the maximum allowed to increase the number of devices compatible. This should not have any impact on the Yubico products.

According to the [specs](https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#extended-length-encoding):
> Let Ne = the maximum length of the response data. In extended length encoding, the maximum value of Ne is 65 536 bytes.
> 
> When Ne = 65 536, let Le1 = 0 and Le2 = 0.

This is, for example, what the Google library also do: https://github.com/google/pyu2f/blob/master/pyu2f/apdu.py#L76

Thanks!
Pierre