### PR TITLE
whitelist U2F/FIDO2 tokens from SoloKeys

### DIFF
--- a/u2flib_host/hid_transport.py
+++ b/u2flib_host/hid_transport.py
@@ -57,6 +57,7 @@ DEVICES = [
     (0x1ea8, 0xf025),  # Thetis U2F
     (0x1d50, 0x60fc),  # OnlyKey U2F
     (0x1209, 0x53c1),  # Trezor U2F/FIDO2
+    (0x0483, 0xa2ca),  # SoloKeys U2F/FIDO2
 ]
 HID_RPT_SIZE = 64
 


### PR DESCRIPTION
Whitelist the USBID of all devices using the firmware from solokeys,

see
https://github.com/solokeys/solo/blob/880d54a4f0e00e32c25b47cfe8482de21a3a49ba/targets/stm32l432/lib/usbd/usbd_desc.c#L53

This concerns all tokens by https://solokeys.com/.

I can confirm that registration and authentication works with the
SOMU version of their tokens.